### PR TITLE
API-1461: Improving urls

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -48,6 +48,6 @@ object FrontendAppConfig extends AppConfig with ServicesConfig {
   override lazy val betaFeedbackUnauthenticatedUrl: String = s"$contactHost/contact/beta-feedback-unauthenticated"
   override lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   override lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
-  override lazy val signInUrl = s"$caFrontendHost/gg/sign-in?continue=$loginCallbackBaseUrl/applications-permissions-withdrawal/applications"
-  override lazy val signOutUrl = s"$caFrontendHost/gg/sign-out?continue=$loginCallbackBaseUrl/applications-permissions-withdrawal/loggedout"
+  override lazy val signInUrl = s"$caFrontendHost/gg/sign-in?continue=$loginCallbackBaseUrl/applications-manage-authority/applications"
+  override lazy val signOutUrl = s"$caFrontendHost/gg/sign-out?continue=$loginCallbackBaseUrl/applications-manage-authority/loggedout"
 }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -25,7 +25,7 @@
 
 @insideHeader = {
     @uiLayouts.header_nav(
-      navTitle = Some("Applications permissions withdrawal"),
+      navTitle = Some("Manage authorised applications"),
       navTitleLink = None,
       showBetaLink = false,
       navLinks = headerNavLinks)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,7 +2,7 @@
 
 GET        /                                           controllers.Revocation.start
 GET        /applications                               controllers.Revocation.listAuthorizedApplications
-GET        /application/:id/withdraw-permission        controllers.Revocation.withdrawPage(id: java.util.UUID)
-POST       /application/:id/withdraw-permission        controllers.Revocation.withdrawAction(id: java.util.UUID)
-GET        /application/:id/permission-withdrawn       controllers.Revocation.withdrawConfirmationPage(id: java.util.UUID)
+GET        /application/:id/remove-authority           controllers.Revocation.withdrawPage(id: java.util.UUID)
+POST       /application/:id/remove-authority           controllers.Revocation.withdrawAction(id: java.util.UUID)
+GET        /application/:id/authority-removed          controllers.Revocation.withdrawConfirmationPage(id: java.util.UUID)
 GET        /loggedout                                  controllers.Revocation.loggedOut

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
-->         /applications-permissions-withdrawal        app.Routes
+->         /applications-manage-authority              app.Routes
 ->         /                                           health.Routes
 ->         /template                                   template.Routes
 

--- a/test/acceptance/pages/AuthorizedApplicationsPage.scala
+++ b/test/acceptance/pages/AuthorizedApplicationsPage.scala
@@ -23,9 +23,9 @@ import org.openqa.selenium.By
 
 object AuthorizedApplicationsPage extends WebPage {
 
-  override val url: String = "http://localhost:9000/applications-permissions-withdrawal/applications"
+  override val url: String = "http://localhost:9000/applications-manage-authority/applications"
 
-  override def isCurrentPage: Boolean = find(cssSelector("h1")).fold(false)(_.text == "Authorised software applications")
+  override def isCurrentPage: Boolean = find(cssSelector("h1")).exists(_.text == "Authorised software applications")
 
   def applicationNameLink(appId: UUID): By = By.cssSelector(s"[data-name-$appId]")
 

--- a/test/acceptance/pages/DynamicPages.scala
+++ b/test/acceptance/pages/DynamicPages.scala
@@ -24,14 +24,14 @@ import org.openqa.selenium.By
 trait DynamicPage extends WebPage {
   val pageHeading: String
 
-  override def isCurrentPage: Boolean = find(tagName("h1")).fold(false)({
+  override def isCurrentPage: Boolean = find(tagName("h1")).exists {
     e => e.text == pageHeading
-  })
+  }
 }
 
 case class WithdrawPermissionPage(applicationId: UUID) extends DynamicPage {
   override val pageHeading = "Remove authority"
-  override val url = s"http://localhost:9000/applications-permissions-withdrawal/$applicationId/withdraw-permission"
+  override val url = s"http://localhost:9000/applications-manage-authority/$applicationId/remove-authority"
 }
 
 object WithdrawPermissionPage {
@@ -42,8 +42,9 @@ object WithdrawPermissionPage {
 }
 
 case class PermissionWithdrawnPage(applicationId: UUID) extends DynamicPage {
+
   override val pageHeading = "Authority removed"
-  override val url = s"http://localhost:9000/applications-permissions-withdrawal/$applicationId/permission-withdrawn"
+  override val url = s"http://localhost:9000/applications-manage-authority/$applicationId/remove-authority"
 }
 
 object PermissionWithdrawnPage {

--- a/test/acceptance/pages/LoginPage.scala
+++ b/test/acceptance/pages/LoginPage.scala
@@ -22,6 +22,6 @@ object LoginPage extends WebPage {
 
   override val url= s"http://localhost:11111/gg/sign-in?continue=${AuthorizedApplicationsPage.url}"
 
-  override def isCurrentPage: Boolean = find(cssSelector("h1")).fold(false)(_.text == "Sign in")
+  override def isCurrentPage: Boolean = find(cssSelector("h1")).exists(_.text == "Sign in")
 
 }

--- a/test/acceptance/pages/StartPage.scala
+++ b/test/acceptance/pages/StartPage.scala
@@ -21,12 +21,11 @@ import org.openqa.selenium.By
 
 object StartPage extends WebPage {
 
-  override val url: String = "http://localhost:9000/applications-permissions-withdrawal/"
+  override val url: String = "http://localhost:9000/applications-manage-authority/"
 
   override def isCurrentPage: Boolean =
     find(cssSelector("h1"))
-      .map(_.text == "Manage the authority you have granted to software applications")
-      .getOrElse(false)
+      .exists(_.text == "Manage the authority you have granted to software applications")
 
   val startButton: By = By.cssSelector("[data-start-button]")
 }

--- a/test/unit/controllers/RevocationSpec.scala
+++ b/test/unit/controllers/RevocationSpec.scala
@@ -83,7 +83,7 @@ class RevocationSpec extends UnitSpec with WithFakeApplication with MockitoSugar
       val result = underTest.listAuthorizedApplications(loggedOutRequest)
 
       status(result) shouldBe 303
-      result.header.headers("Location") shouldEqual "http://localhost:9025/gg/sign-in?continue=http://localhost:9686/applications-permissions-withdrawal/applications"
+      result.header.headers("Location") shouldEqual "http://localhost:9025/gg/sign-in?continue=http://localhost:9686/applications-manage-authority/applications"
     }
   }
 }


### PR DESCRIPTION
As part of the content change push, the urls we use should
use the new terms - to aid understandability.

@haroon also pointed out that we need to change the page title
to use the new terms.