### PR TITLE
API-1465: Adjusted titles and text from review comments

### DIFF
--- a/app/views/revocation/authorizedApplications.scala.html
+++ b/app/views/revocation/authorizedApplications.scala.html
@@ -10,8 +10,11 @@
         </header>
 
         @if(applications.isEmpty) {
-            <p data-info-message>You currently have no authorised software applications.</p>
-            <p>If you want to grant authority to an application you must do it in the application itself.</p>
+            <div data-info-message>
+                <p>You currently have no authorised software applications.</p>
+                <p>If you want to grant authority to an application you must do it in the application itself.</p>
+            </div>
+
         } else {
             <p data-info-message>You have granted authority to the following software applications. You can remove this authority below.</p>
 

--- a/app/views/revocation/permissionWithdrawn.scala.html
+++ b/app/views/revocation/permissionWithdrawn.scala.html
@@ -7,7 +7,7 @@
         </header>
 
         <p data-withdrawn-message>
-            <strong>@{application.name}</strong> no longer has the authority.
+            <strong>@{application.name}</strong> no longer has authority to interact with HMRC on your behalf.
         </p>
 
         <p class="faded-text">You can grant authority again in the <strong>@{application.name}</strong> application.</p>
@@ -19,6 +19,6 @@
     </div>
 }
 
-@main_template(title = "Permission withdrawn") {
+@main_template(title = "Authority removed") {
     @body
 }

--- a/app/views/revocation/start.scala.html
+++ b/app/views/revocation/start.scala.html
@@ -18,6 +18,6 @@
     </div>
 }
 
-@main_template(title = "Withdraw permission to software accessing HMRC data", headerNavLinks = None) {
+@main_template(title = "Manage the authority you have granted to software applications", headerNavLinks = None) {
     @body
 }

--- a/app/views/revocation/withdrawPermission.scala.html
+++ b/app/views/revocation/withdrawPermission.scala.html
@@ -20,6 +20,6 @@
     }
 }
 
-@main_template(title = "Withdraw permission") {
+@main_template(title = "Remove authority") {
     @body
 }

--- a/test/acceptance/NavigationSugar.scala
+++ b/test/acceptance/NavigationSugar.scala
@@ -47,11 +47,11 @@ trait NavigationSugar extends WebBrowser with Eventually with Assertions with Ma
   }
 
   def verifyText(selectorId: String, expected: String)(implicit webDriver: WebDriver) = {
-    webDriver.findElement(By.cssSelector(s"[$selectorId]")).getText contains expected
+    webDriver.findElement(By.cssSelector(s"[$selectorId]")).getText should include (expected)
   }
 
   def verifyText(locator: By, expected: String)(implicit webDriver: WebDriver) = {
-    webDriver.findElement(locator).getText contains expected
+    webDriver.findElement(locator).getText should include (expected)
   }
 
   def redirectedTo(page: WebLink)(implicit webDriver: WebDriver) = {

--- a/test/acceptance/specs/AuthorizedApplicationsSpec.scala
+++ b/test/acceptance/specs/AuthorizedApplicationsSpec.scala
@@ -55,7 +55,7 @@ class AuthorizedApplicationsSpec extends BaseSpec with NavigationSugar {
       go(AuthorizedApplicationsPage)
       on(AuthorizedApplicationsPage)
 
-      verifyText(applicationsMessageText, "You have granted permission to the following software applications to access HMRC data. You can with withdraw this permission at any time.")
+      verifyText(applicationsMessageText, "You have granted authority to the following software applications. You can remove this authority below.")
       applications.foreach(assertApplication)
     }
 
@@ -66,7 +66,8 @@ class AuthorizedApplicationsSpec extends BaseSpec with NavigationSugar {
       go(AuthorizedApplicationsPage)
       on(AuthorizedApplicationsPage)
 
-      verifyText(applicationsMessageText, "There are currently no applications which have access to HMRC data. If you want to grant permission to an application, you must do so in the application itself.")
+      verifyText(applicationsMessageText, "You currently have no authorised software applications.")
+      verifyText(applicationsMessageText, "If you want to grant authority to an application you must do it in the application itself.")
     }
   }
 

--- a/test/acceptance/specs/RevokeApplicationAuthoritySpec.scala
+++ b/test/acceptance/specs/RevokeApplicationAuthoritySpec.scala
@@ -48,11 +48,11 @@ class RevokeApplicationAuthoritySpec extends BaseSpec with NavigationSugar {
       clickOnElement(withdrawPermissionButton(app.application.id))
 
       on(WithdrawPermissionPage(app.application.id))
-      verifyText(withdrawWarningText, s"You are about to stop ${app.application.name} from accessing HMRC data.")
+      verifyText(withdrawWarningText, s"You are about to remove authority from ${app.application.name}.")
       clickOnSubmit()
 
       on(PermissionWithdrawnPage(app.application.id))
-      verifyText(withdrawnMessageText, s"${app.application.name} can no longer access HMRC data.")
+      verifyText(withdrawnMessageText, s"${app.application.name} no longer has authority to interact with HMRC on your behalf.")
       clickOnElement(withdrawnContinueLink)
 
       on(AuthorizedApplicationsPage)


### PR DESCRIPTION
Reviewed at sign-off by the product owner, and a few rough edges
were noticed:

- Some copy in the body text that did not read clearly
- Page titles not using the new terms

Also noticed that our tests weren't actually asserting - they
were using the java String .contains method - which is a predicate,
not an assertion.

Swapped out to use ScalaTest matchers, so that we get nicely
formatted error messages.