### PR TITLE
 API-1596: Ordering by application name 

### DIFF
--- a/app/models/Authority.scala
+++ b/app/models/Authority.scala
@@ -39,6 +39,7 @@ case class AppAuthorisation(application: ThirdPartyApplication,
 
 object AppAuthorisation {
   implicit val format = Json.format[AppAuthorisation]
+  implicit val ordering: Ordering[AppAuthorisation] = Ordering.by(_.application.name)
 }
 
 case class ApplicationDetails(id: UUID, name: String)

--- a/app/service/RevocationService.scala
+++ b/app/service/RevocationService.scala
@@ -31,7 +31,7 @@ trait RevocationService {
 
   def fetchUntrustedApplicationAuthorities()(implicit hc: HeaderCarrier): Future[Seq[AppAuthorisation]] = {
     delegatedAuthorityConnector.fetchApplicationAuthorities().map { authorities =>
-      authorities.filter(!_.application.trusted)
+      authorities.filter(!_.application.trusted).sorted
     }
   }
 

--- a/app/views/revocation/authorizedApplications.scala.html
+++ b/app/views/revocation/authorizedApplications.scala.html
@@ -23,7 +23,7 @@
                     @for(app <- applications) {
                         <li>
                             <details data-@{app.application.id}>
-                                <summary data-name-@{app.application.id}>
+                                <summary data-name-for="@{app.application.id}">
                                     @{app.application.name}
                                 </summary>
                                 <div class="panel-indent">

--- a/test/acceptance/NavigationSugar.scala
+++ b/test/acceptance/NavigationSugar.scala
@@ -22,6 +22,7 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.selenium.WebBrowser
 import org.scalatest.selenium.WebBrowser.{go => goo}
 import org.scalatest.{Assertions, Matchers}
+import scala.collection.convert.decorateAsScala._
 
 trait NavigationSugar extends WebBrowser with Eventually with Assertions with Matchers {
 
@@ -56,6 +57,11 @@ trait NavigationSugar extends WebBrowser with Eventually with Assertions with Ma
 
   def verifyText(locator: By, expected: String)(implicit webDriver: WebDriver) = {
     webDriver.findElement(locator).getText should include (expected)
+  }
+
+  def verifyOrderByText(locator: String, expected: Seq[String])(implicit webDriver: WebDriver) = {
+    val elements = webDriver.findElements(By.cssSelector(locator)).listIterator.asScala.toSeq
+    elements.map(_.getText) == expected
   }
 
   def redirectedTo(page: WebLink)(implicit webDriver: WebDriver) = {

--- a/test/acceptance/pages/AuthorizedApplicationsPage.scala
+++ b/test/acceptance/pages/AuthorizedApplicationsPage.scala
@@ -29,7 +29,9 @@ object AuthorizedApplicationsPage extends WebPage {
 
   val applicationList: String = "data-applications"
 
-  def applicationNameLink(appId: UUID): By = By.cssSelector(s"[data-name-$appId]")
+  val applicationNameLinks: String = "[data-name-for]"
+
+  def applicationNameLink(appId: UUID): By = By.cssSelector(s"[data-name-for='$appId']")
 
   def applicationScopeElement(appId: UUID, scopeKey: String): By = By.cssSelector(s"[data-scope-$appId='$scopeKey']")
 


### PR DESCRIPTION
To provide some sort of sensible ordering to the endusers,
we're ordering the fetched authorities by the application names
(since these are the titles that the user is presented with).